### PR TITLE
Ignore NA in missing date data.

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -53,7 +53,8 @@ request <- function(url) { # nocov start
     names(tbl) %>%
     .[stringr::str_detect(., "date|update|time")]
 
-  tbl %>%
+
+  suppressWarnings( tbl %>%
     mutate_at(
       date_vars,
       clean_date
@@ -61,6 +62,7 @@ request <- function(url) { # nocov start
     mutate(
       request_datetime = lubridate::now()
     )
+  )
 } # nocov end
 
 try_request <- purrr::possibly(
@@ -98,14 +100,14 @@ date_to_int <- function(x) {
 }
 
 clean_date <- function(x) {
-  if (all(stringr::str_detect(x, "[A-Z]+"))) {
+  if (all(stringr::str_detect(x, "[A-Z]+"), na.rm=T)) {
     # For the dateChecked case
     x %>%
       stringr::str_remove_all("[A-Z]+") %>%
       lubridate::as_datetime(
         tz = "America/New_York"
       )
-  } else if (all(stringr::str_detect(x, "/"))) {
+  } else if (all(stringr::str_detect(x, "/"), na.rm=T)) {
     # For the `check_time` case in `get_states_current()`
     x %>%
       stringr::str_replace(" ", "/20 ") %>%


### PR DESCRIPTION
I had an issue with get_states_daily() because some of the 'last_update' values returned from upstream where NA. This patch avoids preserves the NA values instead of returning an empty result.